### PR TITLE
Fix checkbox filter type

### DIFF
--- a/src/Grid/Filter/GallyDynamicFilter.php
+++ b/src/Grid/Filter/GallyDynamicFilter.php
@@ -23,8 +23,7 @@ class GallyDynamicFilter implements FilterInterface
                 $field = str_replace('_boolean', '', $field);
                 $value = ($value === 'true');
                 $dataSource->restrict($dataSource->getExpressionBuilder()->equals($field, $value));
-            } elseif (str_contains($field, '_checkbox')) {
-                $field = str_replace('_checkbox', '', $field);
+            } else {
                 $dataSource->restrict($dataSource->getExpressionBuilder()->equals($field, $value));
             }
         }


### PR DESCRIPTION
In \Gally\SyliusPlugin\Form\Type\Filter\GallyDynamicFilterType::buildForm, the aggregation type is not concatenate in the filter name, but \Gally\SyliusPlugin\Grid\Filter\GallyDynamicFilter::apply expect it to be concatenate.