### PR TITLE
Switch filters to checkboxes

### DIFF
--- a/src/Form/Type/Filter/GallyDynamicFilterType.php
+++ b/src/Form/Type/Filter/GallyDynamicFilterType.php
@@ -12,7 +12,6 @@ use Sylius\Bundle\GridBundle\Form\Type\Filter\SelectFilterType;
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\Extension\Core\Type\RangeType;
 use Symfony\Component\Form\FormBuilderInterface;
-use Symfony\Component\HttpFoundation\RequestStack;
 
 class GallyDynamicFilterType extends AbstractType
 {
@@ -73,8 +72,11 @@ class GallyDynamicFilterType extends AbstractType
                         $aggregation->getField(),
                         SelectFilterType::class,
                         [
+                            'block_prefix' => 'sylius_gally_filter_checkbox',
                             'label' => $aggregation->getLabel(),
                             'choices' => $choices,
+                            'expanded' => true,
+                            'multiple' => true,
                         ]
                     );
                     break;

--- a/src/Grid/Filter/GallyDynamicFilter.php
+++ b/src/Grid/Filter/GallyDynamicFilter.php
@@ -28,7 +28,12 @@ class GallyDynamicFilter implements FilterInterface
                 $value = ($value === 'true');
                 $dataSource->restrict($dataSource->getExpressionBuilder()->equals($field, $value));
             } else {
-                $dataSource->restrict($dataSource->getExpressionBuilder()->equals($field, $value));
+                if (is_array($value)) {
+                    $dataSource->restrict($dataSource->getExpressionBuilder()->in($field, $value));
+                } else {
+                    $dataSource->restrict($dataSource->getExpressionBuilder()->equals($field, $value));
+                }
+
             }
         }
     }

--- a/src/Grid/Gally/ExpressionBuilder.php
+++ b/src/Grid/Gally/ExpressionBuilder.php
@@ -97,7 +97,7 @@ class ExpressionBuilder implements ExpressionBuilderInterface
      */
     public function in(string $field, array $values)
     {
-        throw new \RuntimeException('Method not implemented');
+        return [$field => ['in' => $values]];
     }
 
     /**

--- a/src/Resources/views/Form/_checkbox.html.twig
+++ b/src/Resources/views/Form/_checkbox.html.twig
@@ -1,0 +1,8 @@
+{% block sylius_gally_filter_checkbox_row -%}
+    <div class="{% if required %}required {% endif %}field{% if (not compound or force_error|default(false)) and not valid %} error{% endif %}">
+        {{- form_label(form) -}}
+        {% set attr = attr|merge({'class': attr.class|default ~ ' ui'}) %}
+        {{- form_widget(form, {'attr': attr}) -}}
+        {{- form_errors(form) -}}
+    </div>
+{%- endblock sylius_gally_filter_checkbox_row %}

--- a/src/Resources/views/Grid/Filter/gally_dynamic_filter.html.twig
+++ b/src/Resources/views/Grid/Filter/gally_dynamic_filter.html.twig
@@ -1,5 +1,6 @@
 {% form_theme form with [
     '@SyliusUi/Form/theme.html.twig',
+    '@GallySyliusPlugin/Form/_checkbox.html.twig',
     '@GallySyliusPlugin/Form/_range_widget.html.twig'
 ] %}
 


### PR DESCRIPTION
Fixes #5, fixes #6

Minor issue, though: When submitting filters and the values are not part of the Gally response anymore, Symfony Forms will display an error "The selected choice is invalid." The `Symfony\Component\Form\Extension\Core\Type\ChoiceType::buildForm()` implementation checks for unknown values, and I don't seem to be able to disable this feature out of the box.