### PR TITLE
Fix form problem in PROD mode

### DIFF
--- a/src/Controller/AdminGallyController.php
+++ b/src/Controller/AdminGallyController.php
@@ -51,8 +51,8 @@ final class AdminGallyController extends AbstractController
 
         return $this->render('@GallySyliusPlugin/Config/_form.html.twig', [
             'connectionForm' => $configForm->createView(),
-            'testForm' => $this->createForm(TestConnectionType::class),
-            'syncForm' => $this->createForm(SyncSourceFieldsType::class),
+            'testForm' => $this->createForm(TestConnectionType::class)->createView(),
+            'syncForm' => $this->createForm(SyncSourceFieldsType::class)->createView(),
         ]);
     }
 
@@ -77,9 +77,9 @@ final class AdminGallyController extends AbstractController
         }
 
         return $this->render('@GallySyliusPlugin/Config/_form.html.twig', [
-            'connectionForm' => $this->createForm(GallyConfigurationType::class, $gallyConfiguration),
-            'testForm' => $testForm,
-            'syncForm' => $this->createForm(SyncSourceFieldsType::class),
+            'connectionForm' => $this->createForm(GallyConfigurationType::class, $gallyConfiguration)->createView(),
+            'testForm' => $testForm->createView(),
+            'syncForm' => $this->createForm(SyncSourceFieldsType::class)->createView(),
         ]);
     }
 
@@ -96,9 +96,9 @@ final class AdminGallyController extends AbstractController
         }
 
         return $this->render('@GallySyliusPlugin/Config/_form.html.twig', [
-            'connectionForm' => $this->createForm(GallyConfigurationType::class, $gallyConfiguration),
-            'testForm' => $this->createForm(TestConnectionType::class),
-            'syncForm' => $syncForm,
+            'connectionForm' => $this->createForm(GallyConfigurationType::class, $gallyConfiguration)->createView(),
+            'testForm' => $this->createForm(TestConnectionType::class)->createView(),
+            'syncForm' => $syncForm->createView(),
         ]);
     }
 }


### PR DESCRIPTION
Fixes a problem when running Sylius in production mode:
"An exception has been thrown during the rendering of a template ("Symfony\Component\Form\FormRenderer::setTheme(): Argument #1 ($view) must be of type Symfony\Component\Form\FormView, Symfony\Component\Form\Form given"