### PR TITLE
Fix indexing issue when no product variant is found

### DIFF
--- a/src/Indexer/AbstractIndexer.php
+++ b/src/Indexer/AbstractIndexer.php
@@ -63,6 +63,10 @@ abstract class AbstractIndexer
                     $bulk = [];
                     /** @var array $document */
                     foreach ($this->getDocumentsToIndex($channel, $locale, $documentIdsToReindex) as $document) {
+                        if (0 === \count($document)) {
+                            continue;
+                        }
+                        /* @phpstan-ignore-next-line */
                         $bulk[$document['id']] = json_encode($document);
                         if (\count($bulk) >= $batchSize) {
                             $this->indexOperation->executeBulk($index, $bulk);

--- a/src/Indexer/ProductIndexer.php
+++ b/src/Indexer/ProductIndexer.php
@@ -90,8 +90,11 @@ class ProductIndexer extends AbstractIndexer
     private function formatProduct(ProductInterface $product, ChannelInterface $channel, LocaleInterface $locale): array
     {
         $variants = $product->getVariants();
-        /** @var ProductVariantInterface $variant */
+        /** @var ProductVariantInterface|false $variant */
         $variant = $variants->first();
+        if (false === $variant) {
+            return [];
+        }
 
         /** @var int|string $productId */
         $productId = $product->getId();


### PR DESCRIPTION
I just bumped into an issue in one of our dev setups. I tried to create a product with variants. When saving the parent product before variants have been created, the Gally sync fails because $variant is false in the ProductIndexer.
