### PR TITLE
Fix autocomplete product without image

### DIFF
--- a/src/Resources/views/shop/shared/components/header/search/autocomplete/results.html.twig
+++ b/src/Resources/views/shop/shared/components/header/search/autocomplete/results.html.twig
@@ -61,11 +61,13 @@
                     {% set product_sku = product['sku'] %}
                     {% set product_slug = product['slug'] %}
                     {% set product_price = product['price'][0]['price'] %}
-                    {% set image_path = product['image']|imagine_filter('gally_shop_product_autocomplete_thumbnail') %}
+                    {% set image_path = product['image']|default('') %}
 
                     <a href="{{ path('sylius_shop_product_show', {'slug': product_slug, '_locale': app.request.locale}) }}"
                        class="link-reset col-md-6 mb-3 d-block">
-                        <img class="rounded float-start me-2" src="{{ image_path }}" alt="{{ 'sylius.ui.product'|trans }} {{ product_name }} {{ 'sylius.ui.image'|trans }}" />
+                        {% if image_path is not empty %}
+                        <img class="rounded float-start me-2" src="{{ image_path|imagine_filter('gally_shop_product_autocomplete_thumbnail') }}" alt="{{ 'sylius.ui.product'|trans }} {{ product_name }} {{ 'sylius.ui.image'|trans }}" />
+                        {% endif %}
                         <p class="mb-1"><strong>{{ product_name }}</strong></p>
                         <p class=""><small class="text-body-secondary">{{ money.convertAndFormat(100 * product_price) }}</small></p>
                     </a>


### PR DESCRIPTION
I had an issue with the autocomplete results not rendering due to this error:
```
An exception has been thrown during the rendering of a template ('Parameter "path" for route "liip_imagine_filter" 
must match ".+" ("" given) to generate a corresponding URL.') in
"@GallySyliusPlugin/shop/shared/components/header/search/autocomplete/results.html.twig"
```

I added a bit of logic in the template to also deal with products that don't have images set.