### PR TITLE
Split Twig Hooks file into shop and admin Twig hooks for easier maintenance

### DIFF
--- a/src/Resources/config/app/twig_hooks_admin.yml
+++ b/src/Resources/config/app/twig_hooks_admin.yml
@@ -1,0 +1,60 @@
+sylius_twig_hooks:
+    hooks:
+        'gally_admin.gally.index':
+            sidebar:
+                template: '@SyliusAdmin/shared/crud/common/sidebar.html.twig'
+                priority: 200
+            navbar:
+                template: '@SyliusAdmin/shared/crud/common/navbar.html.twig'
+                priority: 100
+            content:
+                template: '@SyliusAdmin/shared/crud/common/content.html.twig'
+                priority: 0
+                
+        'gally_admin.gally.index.content':
+            header:
+                template: '@SyliusAdmin/shared/crud/common/content/header.html.twig'
+                priority: 200
+            grid:
+                enabled: false
+            configuration:
+                template: '@GallySyliusPlugin/admin/gally/index/configuration.html.twig'
+                priority: 100
+                
+        'gally_admin.gally.index.content.configuration':
+            connection:
+                template: '@GallySyliusPlugin/admin/gally/index/configuration/connection.html.twig'
+                priority: 30
+            test_connection:
+                template: '@GallySyliusPlugin/admin/gally/index/configuration/test_connection.html.twig'
+                priority: 20
+            sync_source_fields:
+                template: '@GallySyliusPlugin/admin/gally/index/configuration/sync_source_fields.html.twig'
+                priority: 10
+        
+        'gally_admin.gally.index.content.header':
+            breadcrumbs:
+                enabled: false
+            title_block:
+                template: '@SyliusAdmin/shared/crud/common/content/header/title_block.html.twig'
+                priority: 0
+                
+        'gally_admin.gally.index.content.header.title_block':
+            title:
+                template: '@SyliusAdmin/shared/crud/common/content/header/title_block/title.html.twig'
+                configuration:
+                    title: Gally
+                    sylius_test_html_attribute: 'gally-config-header'
+                priority: 100
+            actions:
+                enabled: false
+        
+        'sylius_admin.channel.create.content.form.sections':
+            gally:
+                template: '@GallySyliusPlugin/admin/channel/form/sections/gally.html.twig'
+                priority: 0
+
+        'sylius_admin.channel.update.content.form.sections':
+            gally:
+                template: '@GallySyliusPlugin/admin/channel/form/sections/gally.html.twig'
+                priority: 0

--- a/src/Resources/config/app/twig_hooks_shop.yml
+++ b/src/Resources/config/app/twig_hooks_shop.yml
@@ -42,66 +42,6 @@ sylius_twig_hooks:
             gally_filters:
                 template: '@GallySyliusPlugin/shop/product/search/content/body/sidebar/filters.html.twig'
 
-
-        'gally_admin.gally.index':
-            sidebar:
-                template: '@SyliusAdmin/shared/crud/common/sidebar.html.twig'
-                priority: 200
-            navbar:
-                template: '@SyliusAdmin/shared/crud/common/navbar.html.twig'
-                priority: 100
-            content:
-                template: '@SyliusAdmin/shared/crud/common/content.html.twig'
-                priority: 0
-                
-        'gally_admin.gally.index.content':
-            header:
-                template: '@SyliusAdmin/shared/crud/common/content/header.html.twig'
-                priority: 200
-            grid:
-                enabled: false
-            configuration:
-                template: '@GallySyliusPlugin/admin/gally/index/configuration.html.twig'
-                priority: 100
-                
-        'gally_admin.gally.index.content.configuration':
-            connection:
-                template: '@GallySyliusPlugin/admin/gally/index/configuration/connection.html.twig'
-                priority: 30
-            test_connection:
-                template: '@GallySyliusPlugin/admin/gally/index/configuration/test_connection.html.twig'
-                priority: 20
-            sync_source_fields:
-                template: '@GallySyliusPlugin/admin/gally/index/configuration/sync_source_fields.html.twig'
-                priority: 10
-        
-        'gally_admin.gally.index.content.header':
-            breadcrumbs:
-                enabled: false
-            title_block:
-                template: '@SyliusAdmin/shared/crud/common/content/header/title_block.html.twig'
-                priority: 0
-                
-        'gally_admin.gally.index.content.header.title_block':
-            title:
-                template: '@SyliusAdmin/shared/crud/common/content/header/title_block/title.html.twig'
-                configuration:
-                    title: Gally
-                    sylius_test_html_attribute: 'gally-config-header'
-                priority: 100
-            actions:
-                enabled: false
-        
-        'sylius_admin.channel.create.content.form.sections':
-            gally:
-                template: '@GallySyliusPlugin/admin/channel/form/sections/gally.html.twig'
-                priority: 0
-
-        'sylius_admin.channel.update.content.form.sections':
-            gally:
-                template: '@GallySyliusPlugin/admin/channel/form/sections/gally.html.twig'
-                priority: 0
-
         'sylius_shop.base#stylesheets':
             gally:
                 template: "@GallySyliusPlugin/shop/events_stylesheets.html.twig"

--- a/src/Resources/config/config.yml
+++ b/src/Resources/config/config.yml
@@ -1,4 +1,5 @@
 imports:
-  - { resource: "app/twig_hooks.yml" }
-  - { resource: "app/grid.yml" }
   - { resource: "app/filters.yml" }
+  - { resource: "app/grid.yml" }
+  - { resource: "app/twig_hooks_admin.yml" }
+  - { resource: "app/twig_hooks_shop.yml" }


### PR DESCRIPTION
I think it makes sense to split the Twig hooks file to allow for easier maintenance.