### PR TITLE
Decorate Sylius Grid DataProvider

### DIFF
--- a/src/Grid/DataProvider.php
+++ b/src/Grid/DataProvider.php
@@ -21,14 +21,13 @@ use Sylius\Component\Grid\Data\DataSourceProviderInterface;
 use Sylius\Component\Grid\Definition\Grid;
 use Sylius\Component\Grid\Filtering\FiltersApplicatorInterface;
 use Sylius\Component\Grid\Parameters;
-use Sylius\Component\Grid\Sorting\SorterInterface;
 
 final class DataProvider implements DataProviderInterface
 {
     public function __construct(
+        private DataProviderInterface $dataProvider,
         private DataSourceProviderInterface $dataSourceProvider,
         private FiltersApplicatorInterface $filtersApplicator,
-        private SorterInterface $sorter,
         private ChannelContextInterface $channelContext,
     ) {
     }
@@ -46,13 +45,6 @@ final class DataProvider implements DataProviderInterface
             }
         }
 
-        // by default use Sylius' implementation of the data provider
-        $dataProvider = new \Sylius\Component\Grid\Data\DataProvider(
-            $this->dataSourceProvider,
-            $this->filtersApplicator,
-            $this->sorter,
-        );
-
-        return $dataProvider->getData($grid, $parameters);
+        return $this->dataProvider->getData($grid, $parameters);
     }
 }

--- a/src/Resources/config/services/search.xml
+++ b/src/Resources/config/services/search.xml
@@ -27,10 +27,10 @@
         </service>
         <service id="sylius.grid_driver.gally.rest" alias="Gally\SyliusPlugin\Grid\Gally\Driver" />
 
-        <service id="sylius.grid.data_provider" class="Gally\SyliusPlugin\Grid\DataProvider">
+        <service id="Gally\SyliusPlugin\Grid\DataProvider" decorates="sylius.grid.data_provider">
+            <argument type="service" id=".inner" />
             <argument type="service" id="sylius.grid.data_source_provider" />
             <argument type="service" id="sylius.grid.filters_applicator" />
-            <argument type="service" id="sylius.grid.sorter" />
             <argument type="service" id="sylius.context.channel" />
         </service>
 


### PR DESCRIPTION
Instead of hardcoding to return a new data provider instance, return the defined Sylius service via Symfony DI decoration.