### PR TITLE
[Fix] Cast attribute code as string, as Sylius parses it from json

### DIFF
--- a/src/Indexer/Provider/SourceFieldOptionProvider.php
+++ b/src/Indexer/Provider/SourceFieldOptionProvider.php
@@ -72,7 +72,7 @@ class SourceFieldOptionProvider implements ProviderInterface
 
                     yield $this->buildSourceFieldOption(
                         $sourceField,
-                        $code,
+                        (string) $code,
                         (string) $defaultLabel,
                         $translations,
                         ++$position,


### PR DESCRIPTION
With an integer key, fix "Argument #2 $code must be of type string, int given" for select attributes where the key is an integer
