### PR TITLE
Clean up product array with non object data

### DIFF
--- a/src/Grid/Gally/PagerfantaGallyAdapter.php
+++ b/src/Grid/Gally/PagerfantaGallyAdapter.php
@@ -143,6 +143,13 @@ class PagerfantaGallyAdapter implements AdapterInterface
             $productNumbers[$product->getCode()] = $product;
         }
 
+        // clean up products sent from Gally that do not exist in Sylius anymore
+        foreach ($productNumbers as $code => $product) {
+            if (!\is_object($product)) {
+                unset($productNumbers[$code]);
+            }
+        }
+
         /** @var array<(int|string), ProductInterface> $productNumbers */
         return $productNumbers;
     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 2.2.x
| License       | OSL-3.0

Just ran into this problem locally. Gally data was outdated and returned a product which was no longer existing in Sylius. In that case, the replacement logic in sortProductResults() returns an array with product objects an a boolean (true) value. This causes an error in Sylius as it is expected to only return product data.

I could solve this by re-indexing Gally but since this can happen any time, I think the fix in this PR is justified.

Applying the code change will make sure that only objects are returned back to the grid.